### PR TITLE
fix: cannot use ssh service after upgrading system

### DIFF
--- a/src/deepin-system-upgrade-daemon/configs/config.yaml
+++ b/src/deepin-system-upgrade-daemon/configs/config.yaml
@@ -25,6 +25,11 @@ target:
     - "/etc/plymouth/plymouthd.conf"
     - "/etc/xdg/kwinrc"
     - "/etc/apt"
+    - "/etc/ssh"
+    - "/etc/default/ssh"
+    - "/etc/init.d/ssh"
+    - "/etc/ssh/moduli"
+    - "/etc/ufw/applications.d/openssh-server"
 debinstall:
 - "grub2-common"
 - "grub-pc"


### PR DESCRIPTION
ssh cannot work finel because have used the old ssh configs

Log: use new configs
Issue: https://github.com/linuxdeepin/developer-center/issues/3856