### PR TITLE
chore: delete 'only backup the system and not the application' button

### DIFF
--- a/src/deepin-system-upgrade-tool/misc/translations/deepin-system-upgrade-tool_en.ts
+++ b/src/deepin-system-upgrade-tool/misc/translations/deepin-system-upgrade-tool_en.ts
@@ -482,10 +482,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>System backup only, no app backup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Less disk space is required if enabled, but some apps may not work properly after restoring the system from version 23.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/deepin-system-upgrade-tool/misc/translations/deepin-system-upgrade-tool_zh_CN.ts
+++ b/src/deepin-system-upgrade-tool/misc/translations/deepin-system-upgrade-tool_zh_CN.ts
@@ -526,7 +526,7 @@
     </message>
     <message>
         <source>System backup only, no app backup</source>
-        <translation>仅备份系统，不备份应用</translation>
+        <translation type="vanished">仅备份系统，不备份应用</translation>
     </message>
     <message>
         <source>Less disk space is required if enabled, but some apps may not work properly after restoring the system from version 23.</source>

--- a/src/deepin-system-upgrade-tool/misc/translations/deepin-system-upgrade-tool_zh_HK.ts
+++ b/src/deepin-system-upgrade-tool/misc/translations/deepin-system-upgrade-tool_zh_HK.ts
@@ -521,7 +521,7 @@
     </message>
     <message>
         <source>System backup only, no app backup</source>
-        <translation>僅備份系統，不備份應用</translation>
+        <translation type="vanished">僅備份系統，不備份應用</translation>
     </message>
     <message>
         <source>Less disk space is required if enabled, but some apps may not work properly after restoring the system from version 23.</source>

--- a/src/deepin-system-upgrade-tool/misc/translations/deepin-system-upgrade-tool_zh_TW.ts
+++ b/src/deepin-system-upgrade-tool/misc/translations/deepin-system-upgrade-tool_zh_TW.ts
@@ -521,7 +521,7 @@
     </message>
     <message>
         <source>System backup only, no app backup</source>
-        <translation>僅備份系統，不備份應用</translation>
+        <translation type="vanished">僅備份系統，不備份應用</translation>
     </message>
     <message>
         <source>Less disk space is required if enabled, but some apps may not work properly after restoring the system from version 23.</source>

--- a/src/deepin-system-upgrade-tool/src/widgets/storageresultwidget.cpp
+++ b/src/deepin-system-upgrade-tool/src/widgets/storageresultwidget.cpp
@@ -284,26 +284,6 @@ void StorageResultWidget::openCleanupDialog()
         QDesktopServices::openUrl(QUrl::fromLocalFile("/home"));
     });
 
-    // Backup system only switch button
-    BackgroundFrame *frameBackupSystemOnly = new BackgroundFrame;
-    QHBoxLayout *backupSystemOnlyLayout = new QHBoxLayout;
-
-    backupSystemOnlyLayout->setContentsMargins(10, 10, 10, 10);
-    DLabel *backupSystemOnlyTextLabel = new DLabel(tr("System backup only, no app backup"));
-    backupSystemOnlyTextLabel->setForegroundRole(DPalette::TextTitle);
-    backupSystemOnlyTextLabel->setFocusPolicy(Qt::TabFocus);
-    DFontSizeManager::instance()->bind(backupSystemOnlyTextLabel, DFontSizeManager::T6, QFont::Medium);
-    DSwitchButton *backupSystemOnlyButton = new DSwitchButton;
-    backupSystemOnlyLayout->addWidget(backupSystemOnlyTextLabel);
-    backupSystemOnlyLayout->addSpacing(0);
-    backupSystemOnlyLayout->addWidget(backupSystemOnlyButton);
-    frameBackupSystemOnly->setLayout(backupSystemOnlyLayout);
-    backupSystemOnlyButton->setChecked(!dbusWorker->m_isBackupApps);
-
-    DLabel *tipLabel = new DLabel(tr("Less disk space is required if enabled, but some apps may not work properly after restoring the system from version 23."));
-    DFontSizeManager::instance()->bind(tipLabel, DFontSizeManager::T9, QFont::Light);
-    tipLabel->setForegroundRole(DPalette::TextTips);
-
     // Add layout for space cleanup dialog
     dlg.addContent(titleLabel, Qt::AlignCenter);
     dlg.addSpacing(24);
@@ -315,16 +295,10 @@ void StorageResultWidget::openCleanupDialog()
         dlg.addContent(frameDoDataCleanup);
         dlg.addSpacing(4);
     }
-    dlg.addSpacing(6);
-    dlg.addContent(frameBackupSystemOnly);
-    dlg.addSpacing(10);
-    dlg.addContent(tipLabel);
 
     dlg.setIcon(QIcon::fromTheme("dialog-warning"));
     if (dlg.exec() == DDialog::Accepted)
     {
-        dbusWorker->m_isBackupApps = !backupSystemOnlyButton->isChecked();
-        dbusWorker->CancelBackupApp(!dbusWorker->m_isBackupApps);
         emit dbusWorker->StartUpgradeCheck();
     }
 }


### PR DESCRIPTION
because the deepin-system-upgrade tool does not backup applications installed inside /opt directory, so, we need to delete button with this funtion

Log: delete functional button
Issue: https://github.com/linuxdeepin/developer-center/issues/3824