### PR TITLE
fix: Explicitly close QFile checkScriptFile

### DIFF
--- a/src/deepin-system-upgrade-tool/src/tool/image_preparation/isoinfochecker.cpp
+++ b/src/deepin-system-upgrade-tool/src/tool/image_preparation/isoinfochecker.cpp
@@ -23,6 +23,7 @@ IsoInfoChecker::IsoInfoChecker(QObject *parent)
     {
         m_args << QString::fromLatin1(checkScriptFile.readAll());
     }
+    checkScriptFile.close();
 
     connect(m_checkIsoProcess, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &IsoInfoChecker::ExitStatus);
     connect(m_checkIsoProcess, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &IsoInfoChecker::onCheckDone);


### PR DESCRIPTION
When performing iso info check, QFile was not explicitly closed.
Although QFile will call the destructor to automatically close the file when the object goes out of scope, it is a good practice to explicitly close the file to prevent potential code change risks in the future.