### PR TITLE
fix: modify the select all button

### DIFF
--- a/src/deepin-system-upgrade-tool/src/widgets/borderradiusheaderview.cpp
+++ b/src/deepin-system-upgrade-tool/src/widgets/borderradiusheaderview.cpp
@@ -134,7 +134,7 @@ void BorderRadiusHeaderView::mouseReleaseEvent(QMouseEvent* event)
         if(model())
         {
             int section = logicalIndexAt(event->pos());
-            if (section >= 0)
+            if (section == 0)
             {
                 bool checked = model()->headerData(section, orientation(), Qt::CheckStateRole).toBool();
                 model()->setHeaderData(section, orientation(), !checked, Qt::CheckStateRole);


### PR DESCRIPTION
the select all button can be clicked when clicked section 1 in TableWidget header

Log: