### PR TITLE
chore: bump version to 6.0.10

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-system-upgrade (6.0.10) unstable; urgency=medium
+
+  * fix: modify iso address.
+
+ -- Xin Lin <linxin@deepin.org>  Fri, 02 Feb 2024 16:45:00 +0800
+
 deepin-system-upgrade (6.0.9) unstable; urgency=medium
 
   * update iso url to Beta2 


### PR DESCRIPTION
bump version to 6.0.10