### PR TITLE
fix: failed to enable linglong app

### DIFF
--- a/src/deepin-system-upgrade-daemon/pkg/version/manager.go
+++ b/src/deepin-system-upgrade-daemon/pkg/version/manager.go
@@ -342,6 +342,10 @@ func moveLinglongRepo(root, repoPath string) error {
 	if repoPath == "/" {
 		return nil
 	}
+	// fix #7324
+	if _, err := os.Stat("/persistent"); err == nil {
+		return nil
+	}
 	err = os.Mkdir("/persistent", 0755)
 	if err != nil {
 		return err


### PR DESCRIPTION
v23 还原到 v20 后 /persistent 存在，mkdir 失败

Issue: https://github.com/linuxdeepin/developer-center/issues/7324