### PR TITLE
fix: Fix upgrade theme not correct

### DIFF
--- a/src/deepin-system-upgrade-daemon/configs/upgrade.yaml
+++ b/src/deepin-system-upgrade-daemon/configs/upgrade.yaml
@@ -17,4 +17,4 @@ target:
       - "/etc/fstab"
       - "/etc/deepin-upgrade-manager"
  after_run: "/usr/bin/deepin-system-upgrade-tool"
-
+ plymouth_theme: "deepin-upgrade"


### PR DESCRIPTION
Should be used together with https://github.com/linuxdeepin/deepin-upgrade-manager/pull/29

Issue: https://github.com/linuxdeepin/developer-center/issues/7332
Log: Fix upgrade theme not correct