### PR TITLE
fix: Duplicated system restore entries after upgrade

### DIFF
--- a/src/deepin-system-upgrade-daemon/configs/config.yaml
+++ b/src/deepin-system-upgrade-daemon/configs/config.yaml
@@ -30,6 +30,7 @@ target:
     - "/etc/init.d/ssh"
     - "/etc/ssh/moduli"
     - "/etc/ufw/applications.d/openssh-server"
+    - "/etc/grub.d/15_deepin-boot-kit"
 debinstall:
 - "grub2-common"
 - "grub-pc"


### PR DESCRIPTION
Caused by duplicated deepin-boot-kit hook under /etc/grub.d from V20

Issue: https://github.com/linuxdeepin/developer-center/issues/7541
Log: Duplicated system restore entries after upgrade